### PR TITLE
Make the example code for sessions use a status code meant for redirecting

### DIFF
--- a/src/shared/docs/en/http-functions/sessions.md
+++ b/src/shared/docs/en/http-functions/sessions.md
@@ -37,7 +37,7 @@ async function addOne (req) {
   let session = { count }
   let location = '/'
   return {
-    statusCode: 200,
+    statusCode: 307,
     session,
     location
   }
@@ -59,7 +59,7 @@ async function updateUserName (req) {
   let session = { account }
   let location = '/'
   return {
-    statusCode: 200,
+    statusCode: 307,
     session,
     location
   }
@@ -125,7 +125,7 @@ async function login (req) {
   let isLoggedIn = body.email === 'admin' && body.password === 'a-secure-password'
 
   return {
-    statusCode: 200,
+    statusCode: 307,
     session: { isLoggedIn },
     location: '/'
   }
@@ -147,7 +147,7 @@ async function auth (req) {
   }
   else {
     return {
-      statusCode: 200,
+      statusCode: 307,
       location: '/login'
     }
   }


### PR DESCRIPTION
The example code previously used a status code of 200, which would mean user-agents would not read the http location header and redirect to it.
This commit updates the example code to use a 3xx status code, which indicates to user-agents to read the http location header and redirect to it.