### PR TITLE
Update environments.md for .env

### DIFF
--- a/src/shared/docs/en/getting-started/environments.md
+++ b/src/shared/docs/en/getting-started/environments.md
@@ -30,12 +30,13 @@ To delete a variable, simply click the red delete icon.
 
 When working in your development environment, you may need to provide different environment variables. Begin uses [Architect](https://arc.codes/) to run your functions, and the same applies for local development. You can see the environment variables documentation for Architect [here](https://arc.codes/reference/cli/env#the-arc-env-file).
 
-To add an environment variable, first add a `.arc-env` file to your project. This file should also be included in your `.gitignore` file. The `.arc-env` file is automatically read by `arc sandbox` and populates `process.env`
+To add an environment variable, first add a `.env` file to your project. This file should also be included in your `.gitignore` file. The `.env` file is automatically read by `arc sandbox` and populates `process.env`.
 
-For your development environment, you should use the `@testing` environment. Your `.arc-env` file may look like this:
+For your development environment, you should use the `@testing` environment. Your `.env` file may look like this:
 
 ```
-# example .arc-env
+# example .env
 @testing 
-SOME_VAR some-value
+SOME_VAR_1=some-value
+SOME_VAR_2=some-other-value
 ```


### PR DESCRIPTION
Replaces the references to ".arc-env" with ".env" and updates the sample .env file. From @architect/sandbox/src/lib/env/_user-env.js it looks like the .arc-env location is being deprecated in favour of .env and in order for the dotenv module to properly load a .env file lines need to be in the format KEY=VALUE, not KEY VALUE.  (Or at least making these changes was the only way I could get my project to load local environment variables.)

Thank you for helping out! ✨

Before submitting a pull request, please make sure the you checked the following:

- [Y] Forked the repository and created your branch from master
- [N] Make sure the tests pass! `npm it && npm run lint` in the repository root
- [N] If you've fixed a bug or added code **more** tests are appreciated

Sorry!